### PR TITLE
fix: 修复 SkillsSidebar 缺少 PackageSearchIcon 导入导致的运行时白屏

### DIFF
--- a/apps/studio/src/mainview/app/skills/sidebar.tsx
+++ b/apps/studio/src/mainview/app/skills/sidebar.tsx
@@ -5,7 +5,7 @@ import {
   GitBranchIcon,
   LayersIcon,
   BlocksIcon,
-  ShoppingBagIcon,
+  PackageSearchIcon,
   WrenchIcon,
   FolderTreeIcon,
 } from "lucide-react";


### PR DESCRIPTION
## 修复内容

`apps/studio/src/mainview/app/skills/sidebar.tsx` 中使用了 `PackageSearchIcon` 但未导入（误导入了未使用的 `ShoppingBagIcon`）。
导致前端模块在顶层求值时抛出 `ReferenceError: PackageSearchIcon is not defined`，阻断 React 挂载，应用启动后呈白屏状态。

- 补齐 `lucide-react` 中 `PackageSearchIcon` 导入
- 移除未引用的 `ShoppingBagIcon`