### PR TITLE
fix: 收敛字体资源路径长度，修复 Windows 安装包解包中断（#2）

### DIFF
--- a/apps/studio/vite.config.ts
+++ b/apps/studio/vite.config.ts
@@ -27,6 +27,21 @@ export default defineConfig({
     emptyOutDir: true,
     rolldownOptions: {
       external: ["sharp", "@napi-rs/canvas"],
+      output: {
+        // 打包路径必须守住 100 字符：Electrobun 的自解包器是 Zig std.tar，条目名一超过
+        // 100 字符 tar 写入器就改用 GNU long-name（typeflag 'L'）记录，而它读不了这种条目，
+        // 直接 error.TarUnsupportedFileType 中断安装（issue #2 的 win11 装不上）。
+        // 打包后前缀 OmniStudio-canary/Resources/app/views/mainview/assets/ 已占 54 字符，
+        // 而 @fontsource 的字体名本身长 50–55（plus-jakarta-sans-latin-ext-wght-normal-XXXXXXXX.woff2），
+        // 叠起来 104–109 必然越界 —— 实测 v0.0.7-canary.0 里超限的正好只有这 3 个字体。
+        // 收敛成 assets/fonts/<hash>.<ext> 后完整路径约 73 字符，留足余量。
+        assetFileNames: (asset) => {
+          const name = asset.names?.[0] ?? "";
+          return /\.(woff2?|ttf|otf|eot)$/i.test(name)
+            ? "assets/fonts/[hash][extname]"
+            : "assets/[name]-[hash][extname]";
+        },
+      },
     },
   },
   server: {


### PR DESCRIPTION
## 问题（#2）

win11 上运行 canary 安装包，解包到一半中断：

```
DEBUG: Creating file: 'OmniStudio-canary/Resources/app/views/mainview/assets/plsql-fI9PIVwT.js'
error: TarUnsupportedFileType
```

## 根因

Electrobun 的自解包器是 Zig 的 `std.tar`。tar 的 ustar 名字段只有 100 字节，条目名超过 100 字符时写入器会改用 **GNU long-name 记录（typeflag `L`）**，而 `std.tar` 读到这种条目直接 `error.TarUnsupportedFileType` 并中断安装。

对 v0.0.7-canary.0 的 `canary-win-x64-OmniStudio-canary.tar.zst`（851 个条目）实测：

| 检查项 | 结果 |
| --- | --- |
| 路径 > 100 字符的条目 | **3 条，全是字体**（104 / 108 / 109 字符） |
| 条目类型 | 无 symlink / 硬链接；这 3 条前面是 `././@LongLink`（typeflag `L`） |
| tar 顺序 | 这 3 条紧跟 `plsql-fI9PIVwT.js` 之后 = 用户日志里最后成功的那一行 |

越界的是 `@fontsource-variable/plus-jakarta-sans` 的三个 woff2：打包前缀 `OmniStudio-canary/Resources/app/views/mainview/assets/` 占 54 字符，而字体名本身就有 50–55 字符（如 `plus-jakarta-sans-latin-ext-wght-normal-DmpS2jIq.woff2`），加起来必然过线。

## 修法

vite 输出把字体收敛成 `assets/fonts/<hash>.<ext>`，完整路径约 73 字符；其余资源沿用默认命名。CSS 里的 `url()` 由 vite 自动改写，运行期引用不变。

## 验证

- `bun x vite build` 后 `dist` 全树 **0 个**超过 100 字符的路径（最长 94 字符）
- 字体落在 `dist/assets/fonts/`，产物 CSS 已指向新路径
- `lint`（0 error）/ `typecheck`（2/2）/ `bun run test`（335 pass）全绿

## 注意

- 修复要等**下一个 canary 构建**才会进安装包，报 issue 的同学需要在下一版 canary 上复验。
- 余量只剩 6 字符：目前最长的是 mermaid 的 `timeline-definition-*.js`（94 字符）。以后再引入长名依赖资源需要同样处理 —— 可以考虑加一个「打包产物路径 > 100 字符就构建失败」的检查，另开 issue 跟进。

Closes #2
