### PR TITLE
docs: Windows 白屏排障说明（WebView2 GPU 进程崩溃 → --in-process-gpu）（#4）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -205,6 +205,35 @@ See [docs/architecture.md](./docs/architecture.md) for the full architecture (pr
 - [ ] Memory lifecycle (idle unload, prefault protection), KV cache tiering with SSD offload
 - [ ] Menu bar / Dock indicators, API key encryption
 
+## 🩺 Troubleshooting
+
+### Windows: the window opens but the content area is blank
+
+**Symptom**: title bar and menu are there, the content area is one flat colour; the process is alive and the backend is healthy (`http://127.0.0.1:10000/health` responds).
+
+**Cause**: WebView2's **GPU process keeps crashing**. Once Chromium gives up on the GPU it stops producing compositor frames — the page DOM is fully rendered, it just never gets painted ("a page, but no picture"). It is not a frontend or packaging problem, so an even cleaner payload will not help.
+
+**Confirm** (optional): search `%LOCALAPPDATA%\omni-studio.kunpengtalk.com\<channel>\WebView2\Partitions\default\EBWebView\chrome_debug.log` for:
+
+```
+GPU process exited unexpectedly
+GPU process isn't usable. Goodbye.
+```
+
+**Workaround**: force an in-process GPU by setting the env var before launching.
+
+```powershell
+# current session only, then launch OmniStudio from that terminal
+$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--in-process-gpu"
+```
+
+```bat
+:: or persist it (then launch from the Start menu as usual)
+setx WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS "--in-process-gpu"
+```
+
+This flag only helps the GPU-crash flavour of a blank window. If the blank page comes from something else (e.g. a frontend module error) it will not help — for that, check the renderer console instead. Once the GPU driver or WebView2 is updated you can drop the variable and return to the default rendering path.
+
 ## 📄 License
 
 MIT — maintained by 鲲鹏Talk. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -206,6 +206,35 @@ apps/
 - [ ] Memory lifecycle (idle unload, prefault protection), KV cache tiering with SSD offload 内存生命周期与 KV 缓存分层
 - [ ] Menu bar / Dock indicators, API key encryption 菜单栏指标 / Key 加密
 
+## 🩺 常见问题 / 排障
+
+### Windows：窗口能打开，内容区整片空白
+
+**症状**：标题栏、菜单都在，内容区是单一色块；进程活着，后端也正常（`http://127.0.0.1:10000/health` 能返回）。
+
+**原因**：WebView2 的 **GPU 进程反复崩溃**，Chromium 判定 GPU 不可用后就不再产出合成帧 —— 页面 DOM 其实已经渲染好了，只是没画到屏幕上（「有页面、没画面」）。所以这不是前端或安装包的问题，换更干净的载荷也不会变好。
+
+**确认**（可选）：在 `%LOCALAPPDATA%\omni-studio.kunpengtalk.com\<channel>\WebView2\Partitions\default\EBWebView\chrome_debug.log` 里搜：
+
+```
+GPU process exited unexpectedly
+GPU process isn't usable. Goodbye.
+```
+
+**解决**：让 GPU 走进程内实现，启动前设置环境变量。
+
+```powershell
+# 只对当前终端会话生效，随后从该终端启动 OmniStudio
+$env:WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS = "--in-process-gpu"
+```
+
+```bat
+:: 或持久设置（之后照常从开始菜单启动）
+setx WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS "--in-process-gpu"
+```
+
+这个参数**只**对「GPU 进程崩溃型白屏」有效。若是别的原因导致的白屏（例如前端模块报错），它不会让情况变好 —— 那种白屏要看渲染层控制台日志。等显卡驱动或 WebView2 更新后，可以去掉这个变量、恢复默认渲染路径。
+
 ## 📄 许可证
 
 MIT — by 鲲鹏Talk。见 [LICENSE](LICENSE)。


### PR DESCRIPTION
关联 issue #4（**问题 2：主窗口空白**）。上一轮已修问题 1（PR #5）。

## 背景

报告者把这题查到了底，结论非常清楚：**前端是好的**（`#root` 里 DOM 完整、`readyState=complete`、零 JS 异常、零资源失败），真正的问题是 **WebView2 的 GPU 进程反复崩溃**：

```
ERROR:content\browser\gpu\gpu_process_host.cc:1095] GPU process exited unexpectedly: exit_code=1
WARNING:content\browser\gpu\gpu_process_host.cc:1549] The GPU process has crashed 9 time(s)
FATAL:content\browser\gpu\gpu_data_manager_impl_private.cc:436] GPU process isn't usable. Goodbye.
```

GPU 不可用后 Chromium 停止产出合成帧 → DOM 在、画面不在 → 内容区纯白。7 组启动参数对照实验里，`--disable-gpu` / `--use-angle=swiftshader` 等全部无效，**只有 `--in-process-gpu` 能正常渲染**（他复现了 3 次）。

也就是说问题 2 与载荷、与前端代码都无关，属于 **WebView2 / GPU 驱动层面的本机环境问题**；仓库里能落地的部分是把排障路径固化下来。

## 本 PR 做了什么

`README.md`（常见问题 / 排障）+ `README.en.md`（Troubleshooting）各新增一节「Windows：窗口能打开，内容区整片空白」：

- **症状**：标题栏/菜单可见、内容区纯白，但进程与后端（`/health`）都正常
- **原因**：GPU 进程崩溃 → 合成器不出帧（「有页面、没画面」），说明为什么换更干净的载荷也没用
- **确认**：在 WebView2 的 `chrome_debug.log` 里搜 `GPU process exited unexpectedly` / `GPU process isn't usable. Goodbye.`
- **解决**：`WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--in-process-gpu`（PowerShell 临时 / `setx` 持久两种写法），并明确写出**它只对 GPU 崩溃型白屏有效**，避免被当成万能解

## 没有做的事（以及为什么）

报告者建议的「监听 WebView2 的 `ProcessFailed`，自动用 `--in-process-gpu` 重建 WebView」在当前依赖下**做不了**：`electrobun@1.16.0` 只向 bun 侧转发导航/下载类事件（`will-navigate`、`did-navigate`、`dom-ready`、`download-*`、`load-*`），既没有渲染/GPU 进程失败事件，也没有传入额外 WebView2 参数的入口。要做只能先在上游 Electrobun 拿到能力（或升级上游版本），已在 issue 里记为后续项，不在本 PR 里硬凑。

## 校验

`lint` 0 error / `typecheck` 2-2 / `bun test` 482 pass / 0 fail（纯文档改动）。
